### PR TITLE
TDK-7908: L2 Tests for Deepsleep Manager

### DIFF
--- a/docs/pages/deepSleepMgr_L2_Low-Level_TestSpecification.md
+++ b/docs/pages/deepSleepMgr_L2_Low-Level_TestSpecification.md
@@ -57,24 +57,22 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the deep sleep manager using PLAT_DS_INIT | None | DEEPSLEEPMGR_SUCCESS | Should be successful |
-| 02 | Set the deep sleep with a duration of one second and enable GPIO wakeup using PLAT_DS_SetDeepSleep | deep_sleep_timeout=1, isGPIOWakeup=TRUE, networkStandby=FALSE | DEEPSLEEPMGR_SUCCESS | Should be successful |
-| 03 | Sleep for one second | None | None | None |
-| 04 | Wake up from deep sleep using PLAT_DS_DeepSleepWakeup | None | DEEPSLEEPMGR_SUCCESS | Should be successful |
-| 05 | Verify that the wakeup source is GPIO | isGPIOWakeup=true | true | Should be successful |
-| 06 | Terminate the deep sleep manager using PLAT_DS_TERM | None | DEEPSLEEPMGR_SUCCESS | Should be successful |
+| 02 | Set the deep sleep with a duration of one second and enable GPIO wakeup using PLAT_DS_SetDeepSleep | deep_sleep_timeout=1, isGPIOWakeup=valid pointer, networkStandby=false | DEEPSLEEPMGR_SUCCESS | Should be successful |
+| 03 | Wake up from deep sleep using PLAT_DS_DeepSleepWakeup | None | DEEPSLEEPMGR_SUCCESS | Should be successful |
+| 04 | Verify that the wakeup source |  | isGPIOWakeup=false | Should be successful |
+| 05 | Terminate the deep sleep manager using PLAT_DS_TERM | None | DEEPSLEEPMGR_SUCCESS | Should be successful |
 
 
 ```mermaid
 graph TB
 A[Call PLAT_DS_INIT] -->|DEEPSLEEPMGR_SUCCESS| B[Call PLAT_DS_SetDeepSleep]
 A -->|Failure| A1[Test case fail]
-B -->|DEEPSLEEPMGR_SUCCESS| C[Wait for 1 second]
+B -->|DEEPSLEEPMGR_SUCCESS| D[Call PLAT_DS_DeepSleepWakeup]
 B -->|Failure| B1[Test case fail]
-C --> D[Call PLAT_DS_DeepSleepWakeup]
 D -->|DEEPSLEEPMGR_SUCCESS| E[Verify isGPIOWakeup]
 D -->|Failure| D1[Test case fail]
-E -->|isGPIOWakeup TRUE| F[Call PLAT_DS_TERM]
-E -->|isGPIOWakeup FALSE| E1[Test case fail]
+E -->|isGPIOWakeup False| F[Call PLAT_DS_TERM]
+E -->|isGPIOWakeup True| E1[Test case fail]
 F -->|DEEPSLEEPMGR_SUCCESS| G[Test case success]
 F -->|Failure| F1[Test case fail]
 ```
@@ -105,10 +103,9 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the platform deep sleep manager using PLAT_DS_INIT | None | DEEPSLEEPMGR_SUCCESS | Should be successful |
 | 02 | Set the deep sleep with a duration of ten seconds using PLAT_DS_SetDeepSleep | deep_sleep_timeout = 10, isGPIOWakeup = valid pointer, networkStandby = true | DEEPSLEEPMGR_SUCCESS | Should be successful |
-| 03 | Sleep for ten seconds | None | None | None |
-| 04 | Check the wake-up source | None | None | None |
-| 05 | Wake up from deep sleep using PLAT_DS_DeepSleepWakeup | None | DEEPSLEEPMGR_SUCCESS | Should be successful |
-| 06 | Terminate the platform deep sleep manager using PLAT_DS_TERM | None | DEEPSLEEPMGR_SUCCESS | Should be successful |
+| 03 | Wake up from deep sleep using PLAT_DS_DeepSleepWakeup | None | DEEPSLEEPMGR_SUCCESS | Should be successful |
+| 04 | Verify that the wakeup source |  | isGPIOWakeup=false | Should be successful |
+| 05 | Terminate the platform deep sleep manager using PLAT_DS_TERM | None | DEEPSLEEPMGR_SUCCESS | Should be successful |
 
 
 ```mermaid

--- a/docs/pages/deepSleepMgr_L2_Low-Level_TestSpecification.md
+++ b/docs/pages/deepSleepMgr_L2_Low-Level_TestSpecification.md
@@ -1,0 +1,128 @@
+# DEEPSLEEPMGR L2 Low Level Test Specification and Procedure Documentation
+
+## Table of Contents
+
+- [DEEPSLEEPMGR L2 Low Level Test Specification and Procedure Documentation](#deepsleepmgr-l2-low-level-test-specification-and-procedure-documentation)
+
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+    - [Acronyms, Terms and Abbreviations](#acronyms-terms-and-abbreviations)
+    - [Definitions](#definitions)
+    - [References](#references)
+  - [Level 2 Test Procedure](#level-2-test-procedure)
+
+## Overview
+
+This document describes the level 2 testing suite for the DEEPSLEEPMGR module.
+
+### Acronyms, Terms and Abbreviations
+
+- `HAL` \- Hardware Abstraction Layer, may include some common components
+- `UT`  \- Unit Test(s)
+- `OEM`  \- Original Equipment Manufacture
+- `SoC`  \- System on a Chip
+
+### Definitions
+
+  - `ut-core` \- Common Testing Framework <https://github.com/rdkcentral/ut-core>, which wraps a open-source framework that can be expanded to the requirements for future framework.
+
+### References
+- `High Level Test Specification` - [deepsleep-manager_TestSpec.md](deepsleep-manager_TestSpec.md)
+
+## Level 2 Test Procedure
+
+The following functions are expecting to test the module operates correctly.
+
+### Test 1
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_deepSleepMgr_SetDeepSleepAndVerifyWakeup1`|
+|Description|Set the deep sleep with a duration of one second and verify the wake-up source|
+|Test Group|Module : 02|
+|Test Case ID|001|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the deep sleep manager using PLAT_DS_INIT | None | DEEPSLEEPMGR_SUCCESS | Should be successful |
+| 02 | Set the deep sleep with a duration of one second and enable GPIO wakeup using PLAT_DS_SetDeepSleep | deep_sleep_timeout=1, isGPIOWakeup=TRUE, networkStandby=FALSE | DEEPSLEEPMGR_SUCCESS | Should be successful |
+| 03 | Sleep for one second | None | None | None |
+| 04 | Wake up from deep sleep using PLAT_DS_DeepSleepWakeup | None | DEEPSLEEPMGR_SUCCESS | Should be successful |
+| 05 | Verify that the wakeup source is GPIO | isGPIOWakeup=true | true | Should be successful |
+| 06 | Terminate the deep sleep manager using PLAT_DS_TERM | None | DEEPSLEEPMGR_SUCCESS | Should be successful |
+
+
+```mermaid
+graph TB
+A[Call PLAT_DS_INIT] -->|DEEPSLEEPMGR_SUCCESS| B[Call PLAT_DS_SetDeepSleep]
+A -->|Failure| A1[Test case fail]
+B -->|DEEPSLEEPMGR_SUCCESS| C[Wait for 1 second]
+B -->|Failure| B1[Test case fail]
+C --> D[Call PLAT_DS_DeepSleepWakeup]
+D -->|DEEPSLEEPMGR_SUCCESS| E[Verify isGPIOWakeup]
+D -->|Failure| D1[Test case fail]
+E -->|isGPIOWakeup TRUE| F[Call PLAT_DS_TERM]
+E -->|isGPIOWakeup FALSE| E1[Test case fail]
+F -->|DEEPSLEEPMGR_SUCCESS| G[Test case success]
+F -->|Failure| F1[Test case fail]
+```
+
+
+### Test 2
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_deepSleepMgr_SetDeepSleepAndVerifyWakeUp10`|
+|Description|Set the deep sleep with a duration of ten seconds and verify the wake-up source|
+|Test Group|Module : 02|
+|Test Case ID|002|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the platform deep sleep manager using PLAT_DS_INIT | None | DEEPSLEEPMGR_SUCCESS | Should be successful |
+| 02 | Set the deep sleep with a duration of ten seconds using PLAT_DS_SetDeepSleep | deep_sleep_timeout = 10, isGPIOWakeup = valid pointer, networkStandby = true | DEEPSLEEPMGR_SUCCESS | Should be successful |
+| 03 | Sleep for ten seconds | None | None | None |
+| 04 | Check the wake-up source | None | None | None |
+| 05 | Wake up from deep sleep using PLAT_DS_DeepSleepWakeup | None | DEEPSLEEPMGR_SUCCESS | Should be successful |
+| 06 | Terminate the platform deep sleep manager using PLAT_DS_TERM | None | DEEPSLEEPMGR_SUCCESS | Should be successful |
+
+
+```mermaid
+graph TB
+A[Call PLAT_DS_INIT] -->|DEEPSLEEPMGR_SUCCESS| B[Call PLAT_DS_SetDeepSleep]
+A -->|Failure| A1[Test case fail]
+B -->|DEEPSLEEPMGR_SUCCESS| C[Wait for 10 seconds]
+B -->|Failure| B1[Test case fail]
+C --> D[Verify wake-up source]
+D -->|isGPIOWakeup is true| E[Call PLAT_DS_DeepSleepWakeup]
+E -->|DEEPSLEEPMGR_SUCCESS| F[Call PLAT_DS_TERM]
+E -->|Failure| E1[Test case fail]
+F -->|DEEPSLEEPMGR_SUCCESS| G[Test case success]
+F -->|Failure| F1[Test case fail]
+```
+
+

--- a/src/main.c
+++ b/src/main.c
@@ -1,104 +1,42 @@
-/**
-*  If not stated otherwise in this file or this component's LICENSE
-*  file the following copyright and licenses apply:
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:*
+* Copyright 2024 RDK Management
 *
-*  Copyright 2022 RDK Management
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
 *
-*  Licensed under the Apache License, Version 2.0 (the License);
-*  you may not use this file except in compliance with the License.
-*  You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
 *
-*  http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing, software
-*  distributed under the License is distributed on an AS IS BASIS,
-*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*  See the License for the specific language governing permissions and
-*  limitations under the License.
-*/
-
-/**
- * @addtogroup HPK Hardware Porting Kit
- * @{
- * @par The Hardware Porting Kit
- * HPK is the next evolution of the well-defined Hardware Abstraction Layer
- * (HAL), but augmented with more comprehensive documentation and test suites
- * that OEM or SOC vendors can use to self-certify their ports before taking
- * them to RDKM for validation or to an operator for final integration and
- * deployment. The Hardware Porting Kit effectively enables an OEM and/or SOC
- * vendor to self-certify their own Video Accelerator devices, with minimal RDKM
- * assistance.
- *
- */
-
-/**
- * @addtogroup Deepsleep_Manager Deep Sleep Manager
- * @{
- * @par Application API Specification
- */
-
-/**
- * @defgroup Deepsleep_Manager_HALTEST Deep Sleep Manager HALTEST
- * @{
- *
- */
-
-/**
- * @defgroup Deepsleep_Mgr_HALTEST_MAIN Deep Sleep Manager HALTEST Main File
- * @{
- * @parblock
- * ### Tests for Deepsleep Manager HAL :
- *
- * This is to ensure that the APIs meets the operational requirements of the module across all vendors.
- *
- * **Pre-Conditions:**  None@n
- * **Dependencies:** None@n
- *
- * Ref to API Definition specification documentation : [deepsleep-manager_halSpec.md](../../docs/pages/deepsleep-manager_halSpec.md)
- * @endparblock
- */
-
-/**
-* @file main.c
-*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 */
 
 #include <ut.h>
 
-extern int UT_register_APIDEF_l1_tests( void );
-extern int UT_register_APIDEF_l2_tests( void );
+extern int register_hal_l2_tests( void );
 
-int main(int argc, char** argv) 
+int main(int argc, char** argv)
 {
-	int registerReturn = 0;
-
-	/* Register tests as required, then call the UT-main to support switches and triggering */
-	UT_init( argc, argv );
-
-	/* Check if tests are registered successfully */
-
-	registerReturn = UT_register_APIDEF_l1_tests();
-	if ( registerReturn == -1 )
-	{
-		printf("\n UT_register_APIDEF_l1_tests() returned failure");
-		return -1;
-	}
-
-	registerReturn = UT_register_APIDEF_l2_tests();
-	if ( registerReturn == -1 )
-	{	
-		printf("\n UT_register_APIDEF_l2_tests() returned failure");
-		return -1;
-	}
-
-	/* Begin test executions */
-	UT_run_tests();
-
-	return 0;
-
+    int registerReturn = 0;
+    /* Register tests as required, then call the UT-main to support switches and triggering */
+    UT_init( argc, argv );
+    /* Check if tests are registered successfully */
+    registerReturn = register_hal_l2_tests();
+    if (registerReturn == 0)
+    {
+        printf("register_hal_l2_tests() returned success");
+    }
+    else
+    {
+        printf("register_hal_l2_tests() returned failure");
+        return 1;
+    }
+    /* Begin test executions */
+    UT_run_tests();
+    return 0;
 }
-
-/** @} */ // End of Deepsleep_Mgr_HALTEST_MAIN
-/** @} */ // End of Deepsleep_Manager_HALTEST
-/** @} */ // End Deepsleep_Manager
-/** @} */ // End of HPK

--- a/src/test_l2_deepSleepMgr.c
+++ b/src/test_l2_deepSleepMgr.c
@@ -33,7 +33,6 @@
 #include <ut.h>
 #include <ut_log.h>
 #include <ut_kvp_profile.h>
-#include <unistd.h>
 #include "deepSleepMgr.h"
 
 static int gTestGroup = 2;
@@ -57,14 +56,14 @@ void test_l2_deepSleepMgr_SetDeepSleepAndVerifyWakeup1(void)
     UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
     DeepSleep_Return_Status_t status;
-    bool isGPIOWakeup = false;
+    bool isGPIOWakeup ;
 
     UT_LOG_DEBUG("Invoking PLAT_DS_INIT");
     status = PLAT_DS_INIT();
     UT_LOG_DEBUG("Return status: %d", status);
     UT_ASSERT_EQUAL_FATAL(status, DEEPSLEEPMGR_SUCCESS);
 
-    UT_LOG_DEBUG("Invoking PLAT_DS_SetDeepSleep with deep_sleep_timeout=1, isGPIOWakeup=TRUE, networkStandby=FALSE");
+    UT_LOG_DEBUG("Invoking PLAT_DS_SetDeepSleep with deep_sleep_timeout=1, isGPIOWakeup= valid pointer, networkStandby=FALSE");
     status = PLAT_DS_SetDeepSleep(1, &isGPIOWakeup, false);
     UT_LOG_DEBUG("Return status: %d, isGPIOWakeup: %d", status, isGPIOWakeup);
     UT_ASSERT_EQUAL(status, DEEPSLEEPMGR_SUCCESS);
@@ -76,13 +75,11 @@ void test_l2_deepSleepMgr_SetDeepSleepAndVerifyWakeup1(void)
         return;
     }
 
-    sleep(1);
-
     UT_LOG_DEBUG("Invoking PLAT_DS_DeepSleepWakeup");
     status = PLAT_DS_DeepSleepWakeup();
     UT_LOG_DEBUG("Return status: %d", status);
     UT_ASSERT_EQUAL(status, DEEPSLEEPMGR_SUCCESS);
-    UT_ASSERT_EQUAL(isGPIOWakeup, true);
+    UT_ASSERT_EQUAL(isGPIOWakeup, false);
     if (status != DEEPSLEEPMGR_SUCCESS)
     {
         UT_LOG_ERROR("PLAT_DS_DeepSleepWakeup failed with status: %d", status);
@@ -119,7 +116,7 @@ void test_l2_deepSleepMgr_SetDeepSleepAndVerifyWakeUp10(void)
     DeepSleep_Return_Status_t status;
     bool isGPIOWakeup;
     uint32_t deep_sleep_timeout = 10;
-    bool networkStandby = true;
+    bool networkStandby = false;
 
     UT_LOG_DEBUG("Invoking PLAT_DS_INIT");
     status = PLAT_DS_INIT();
@@ -139,13 +136,11 @@ void test_l2_deepSleepMgr_SetDeepSleepAndVerifyWakeUp10(void)
         return;
     }
 
-    sleep(10);
-
     UT_LOG_DEBUG("Invoking PLAT_DS_DeepSleepWakeup");
     status = PLAT_DS_DeepSleepWakeup();
     UT_LOG_DEBUG("Return status: %d", status);
     UT_ASSERT_EQUAL(status, DEEPSLEEPMGR_SUCCESS);
-    UT_ASSERT_EQUAL(isGPIOWakeup, true);
+    UT_ASSERT_EQUAL(isGPIOWakeup, false);
     if (status != DEEPSLEEPMGR_SUCCESS)
     {
         UT_LOG_ERROR("PLAT_DS_DeepSleepWakeup failed with status: %d", status);

--- a/src/test_register.c
+++ b/src/test_register.c
@@ -1,104 +1,30 @@
-/**
-*  If not stated otherwise in this file or this component's LICENSE 
-*  file the following copyright and licenses apply:
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:*
+* Copyright 2024 RDK Management
 *
-*  Copyright 2022 RDK Management
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
 *
-*  Licensed under the Apache License, Version 2.0 (the License);
-*  you may not use this file except in compliance with the License.
-*  You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
 *
-*  http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing, software
-*  distributed under the License is distributed on an AS IS BASIS,
-*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*  See the License for the specific language governing permissions and
-*  limitations under the License.
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 */
-
-#include <ut.h>
-
-/**
- * @addtogroup HPK Hardware Porting Kit
- * @{
- * @par The Hardware Porting Kit
- * HPK is the next evolution of the well-defined Hardware Abstraction Layer
- * (HAL), but augmented with more comprehensive documentation and test suites
- * that OEM or SOC vendors can use to self-certify their ports before taking
- * them to RDKM for validation or to an operator for final integration and
- * deployment. The Hardware Porting Kit effectively enables an OEM and/or SOC
- * vendor to self-certify their own Video Accelerator devices, with minimal RDKM
- * assistance.
- *
- */
-
-/**
- * @addtogroup Deepsleep_Manager Deep Sleep Manager
- * @{
- * @par Application API Specification
- */
-
-/**
- * @addtogroup Deepsleep_Manager_HALTEST Deep Sleep Manager HALTEST
- * @{
- */
-
-/**
- * @defgroup Deepsleep_Mgr_HALTEST_REGISTER Deep Sleep Manager HALTEST Register File
- * @{
- * ### Registration of tests for Deepsleep Manager HAL :
- *
- * Registration of tests for Deepsleep Manager HAL.
- * This is to ensure that the APIs meets the operational requirements of the module across all vendors.
- *
- * **Pre-Conditions:**  None@n
- * **Dependencies:** None@n
- *
- * Ref to API Definition specification documentation : [deepsleep-manager_halSpec.md](../../docs/pages/deepsleep-manager_halSpec.md)
- *
- */
-
-
-/**
-* @file test_register.c
-*
-*/
-
-
-
-/**
- * @brief Register test functionality
- * 
- */
-
-/* L1 Testing Functions */
-extern int test_l1_deepSleepMgr_register( void );
-
 
 /* L2 Testing Functions */
-extern int test_l2_deepSleepMgr_register( void );
 
-int UT_register_APIDEF_l1_tests( void )
+extern int test_deepSleepMgr_l2_register(void);
+
+int register_hal_l2_tests( void )
 {
-	int registerFailed=0;
+    int registerFailed=0;
 
-	registerFailed |= test_l1_deepSleepMgr_register();
+    registerFailed |= test_deepSleepMgr_l2_register();
 
-	return registerFailed;
+    return registerFailed;
 }
-
-/* Register UT Functions */
-int UT_register_APIDEF_l2_tests( void )
-{
-	int registerFailed=0;
-
-	registerFailed |= test_l2_deepSleepMgr_register();
-
-	return registerFailed;
-}
-
-/** @} */ // End of Deepsleep_Mgr_HALTEST_REGISTER
-/** @} */ // End of Deepsleep_Manager_HALTEST
-/** @} */ // End Deepsleep_Manager
-/** @} */ // End of HPK


### PR DESCRIPTION
Reason for change: Generate L2 tests for Deepsleep Manager
Risks: Low
Test Procedure: Execute the hal test binary