### PR TITLE
L1 - YAML variable mismatch with C code causes parsing failure.

### DIFF
--- a/profiles/deepsleepmanagerExtendedEnumsNotSupported.yaml
+++ b/profiles/deepsleepmanagerExtendedEnumsNotSupported.yaml
@@ -1,4 +1,4 @@
-deepsleep:
+deepsleepmanager:
   features:
     extendedEnumsSupported: false
 

--- a/profiles/sinkWakeUpSources.yaml
+++ b/profiles/sinkWakeUpSources.yaml
@@ -1,4 +1,4 @@
-deepsleep:
+deepsleepmanager:
   features:
     extendedEnumsSupported: false
 


### PR DESCRIPTION
The issue occurs due to a mismatch between the variable names in the YAML file and the C code, leading to a parsing failure. When the parser attempts to read and map the YAML variables to the corresponding C structures or definitions, it fails due to the inconsistency. This can result in incorrect configurations, unexpected behavior, or runtime errors.