### PR TITLE
gh47 Deepsleep L3 test suite failed to run as parameter is missing for deepsleepClass

### DIFF
--- a/bin/powermanager/run.sh
+++ b/bin/powermanager/run.sh
@@ -21,4 +21,4 @@
 
 cd "$(dirname "$0")"
 export LD_LIBRARY_PATH=/usr/lib:/lib:/home/root:./
-./hal_test $@
+./hal_test_iarmmgrs-power-hal $@

--- a/host/tests/deepsleep_L3_Tests/test1_TriggerDeepsleep.py
+++ b/host/tests/deepsleep_L3_Tests/test1_TriggerDeepsleep.py
@@ -48,6 +48,7 @@ class deepsleep_test1_TriggerDeepsleep(utHelperClass):
             None.
         """
         self.testName  = "test1_TriggerDeepsleep"
+        self.testsuite  = "L3 Deepsleep manager"
         self.testSetupPathPower = dir_path + "/power_L3_testSetup.yml"
         self.testSetupPathDeepsleep = dir_path + "/deepsleep_L3_testSetup.yml"
         self.moduleNameDeepsleep = "deepsleep"
@@ -293,7 +294,7 @@ class deepsleep_test1_TriggerDeepsleep(utHelperClass):
             bool : Test results
         """
         # Create the deepsleep manager class
-        self.testDeepsleep = deepsleepClass(self.moduleConfigProfileFile, self.hal_session_deepsleep, self.targetWorkspaceDeepsleep)
+        self.testDeepsleep = deepsleepClass(self.moduleConfigProfileFile, self.hal_session_deepsleep, self.testsuite, self.targetWorkspaceDeepsleep)
         # Create the Power Manager Class
         self.testPower = powerManagerClass(self.moduleConfigProfileFile, self.hal_session_power, self.targetWorkspacePower)
 


### PR DESCRIPTION
Deepsleep L3 test suite failed to run as parameter is missing for deepsleepClass.
Added the parameter in deepsleepClass this will run L3 dsHost test suite.
Also updated the powermanager hal test binary in bin/powermanager/run.sh